### PR TITLE
Add simple track map overlay

### DIFF
--- a/OverlayTrackMap.h
+++ b/OverlayTrackMap.h
@@ -1,0 +1,123 @@
+/*
+MIT License
+
+Copyright (c) 2021-2022 L. E. Spalt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#pragma once
+
+#include <vector>
+#include <float.h>
+#include <math.h>
+#include "Overlay.h"
+#include "iracing.h"
+#include "Config.h"
+
+class OverlayTrackMap : public Overlay
+{
+public:
+    OverlayTrackMap()
+        : Overlay("OverlayTrackMap")
+    {}
+
+protected:
+    struct Point { float x; float y; };
+    std::vector<Point> m_points;
+    double             m_lastTime = 0.0;
+    float              m_lastPct = 0.0f;
+    bool               m_lapDone = false;
+
+    virtual float2 getDefaultSize()
+    {
+        return float2(200,200);
+    }
+
+    virtual void onEnable()
+    {
+        m_points.clear();
+        m_lastTime = ir_SessionTime.getDouble();
+        m_lastPct = ir_LapDistPct.getFloat();
+        m_lapDone = false;
+    }
+
+    virtual void onDisable()
+    {
+        m_points.clear();
+    }
+
+    virtual void onUpdate()
+    {
+        double t = ir_SessionTime.getDouble();
+        float dt = (float)(t - m_lastTime);
+        m_lastTime = t;
+
+        float yaw = ir_Yaw.getFloat();
+        float speed = ir_Speed.getFloat();
+
+        float dx = cosf(yaw) * speed * dt;
+        float dy = sinf(yaw) * speed * dt;
+
+        Point p = m_points.empty() ? Point{0,0} : m_points.back();
+        p.x += dx;
+        p.y += dy;
+        m_points.push_back(p);
+
+        float pct = ir_LapDistPct.getFloat();
+        if( pct < m_lastPct && m_points.size() > 10 )
+            m_lapDone = true;
+        m_lastPct = pct;
+
+        if( !m_lapDone )
+            return;
+
+        if( m_points.size() < 2 )
+            return;
+
+        float minx=FLT_MAX, miny=FLT_MAX, maxx=-FLT_MAX, maxy=-FLT_MAX;
+        for( const Point& pt : m_points )
+        {
+            if( pt.x < minx ) minx = pt.x;
+            if( pt.y < miny ) miny = pt.y;
+            if( pt.x > maxx ) maxx = pt.x;
+            if( pt.y > maxy ) maxy = pt.y;
+        }
+        const float scale = 0.9f * std::min((float)m_width/(maxx-minx+1e-3f), (float)m_height/(maxy-miny+1e-3f));
+        const float offx = (float)m_width*0.5f - (minx+maxx)*0.5f*scale;
+        const float offy = (float)m_height*0.5f - (miny+maxy)*0.5f*scale;
+
+        Microsoft::WRL::ComPtr<ID2D1PathGeometry1> path;
+        Microsoft::WRL::ComPtr<ID2D1GeometrySink> sink;
+        m_d2dFactory->CreatePathGeometry(&path);
+        path->Open(&sink);
+        sink->BeginFigure(float2(m_points[0].x*scale+offx, m_points[0].y*scale+offy), D2D1_FIGURE_BEGIN_HOLLOW);
+        for(size_t i=1;i<m_points.size();++i)
+            sink->AddLine(float2(m_points[i].x*scale+offx, m_points[i].y*scale+offy));
+        sink->EndFigure(D2D1_FIGURE_END_OPEN);
+        sink->Close();
+
+        m_renderTarget->BeginDraw();
+        const float thickness = g_cfg.getFloat(m_name, "line_thickness", 2.0f);
+        m_brush->SetColor(g_cfg.getFloat4(m_name, "line_col", float4(1,1,1,1)) );
+        m_renderTarget->DrawGeometry(path.Get(), m_brush.Get(), thickness);
+        m_renderTarget->EndDraw();
+    }
+};
+

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ The project's code base aims to be small, easy to modify, and free of external d
 
 - [Where to Download](#where-to-download)
 - [Overlays](#overlays)
-  - [*Relative*](#relative)
+- [*Relative*](#relative)
+- [*Map*](#map)
   - [*DDU*](#ddu)
   - [*Inputs*](#inputs)
   - [*Standings*](#standings)
@@ -37,6 +38,12 @@ Like the *Relative* box in iRacing, but with additional information such as lice
 At the top is an optional minimap. It can be set to either relative mode (own car fixed in the center) or absolute mode (start/finish line fixed in the center).
 
 ![relative](https://github.com/lespalt/iRon/blob/main/relative.png?raw=true)
+
+### *Map*
+
+Builds a simple track map based on the car's position after completing
+one lap. The map is drawn using the telemetry-provided speed and yaw
+data, and becomes visible once enough data has been gathered.
 
 ### *DDU*
 

--- a/iron.vcxproj
+++ b/iron.vcxproj
@@ -162,6 +162,7 @@
     <ClInclude Include="OverlayDDU.h" />
     <ClInclude Include="OverlayDebug.h" />
     <ClInclude Include="OverlayInputs.h" />
+    <ClInclude Include="OverlayTrackMap.h" />
     <ClInclude Include="iracing.h" />
     <ClInclude Include="irsdk\irsdk_client.h" />
     <ClInclude Include="irsdk\irsdk_defines.h" />

--- a/iron.vcxproj.filters
+++ b/iron.vcxproj.filters
@@ -42,6 +42,7 @@
     <ClInclude Include="OverlayDebug.h" />
     <ClInclude Include="OverlayDDU.h" />
     <ClInclude Include="OverlayCover.h" />
+    <ClInclude Include="OverlayTrackMap.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="LICENSE" />

--- a/main.cpp
+++ b/main.cpp
@@ -38,6 +38,7 @@ SOFTWARE.
 #include "Config.h"
 #include "OverlayCover.h"
 #include "OverlayRelative.h"
+#include "OverlayTrackMap.h"
 #include "OverlayInputs.h"
 #include "OverlayStandings.h"
 #include "OverlayDebug.h"
@@ -50,7 +51,8 @@ enum class Hotkey
     DDU,
     Inputs,
     Relative,
-    Cover
+    Cover,
+    Map
 };
 
 static void registerHotkeys()
@@ -61,6 +63,7 @@ static void registerHotkeys()
     UnregisterHotKey( NULL, (int)Hotkey::Inputs );
     UnregisterHotKey( NULL, (int)Hotkey::Relative );
     UnregisterHotKey( NULL, (int)Hotkey::Cover );
+    UnregisterHotKey( NULL, (int)Hotkey::Map );
 
     UINT vk, mod;
 
@@ -81,6 +84,9 @@ static void registerHotkeys()
 
     if( parseHotkey( g_cfg.getString("OverlayCover","toggle_hotkey","ctrl-4"),&mod,&vk) )
         RegisterHotKey( NULL, (int)Hotkey::Cover, mod, vk );
+
+    if( parseHotkey( g_cfg.getString("OverlayTrackMap","toggle_hotkey","ctrl-5"),&mod,&vk) )
+        RegisterHotKey( NULL, (int)Hotkey::Map, mod, vk );
 }
 
 static void handleConfigChange( std::vector<Overlay*> overlays, ConnectionStatus status )
@@ -129,6 +135,7 @@ int main()
     printf("    Toggle inputs overlay:        %s\n", g_cfg.getString("OverlayInputs","toggle_hotkey","").c_str() );
     printf("    Toggle relative overlay:      %s\n", g_cfg.getString("OverlayRelative","toggle_hotkey","").c_str() );
     printf("    Toggle cover overlay:         %s\n", g_cfg.getString("OverlayCover","toggle_hotkey","").c_str() );
+    printf("    Toggle map overlay:           %s\n", g_cfg.getString("OverlayTrackMap","toggle_hotkey","").c_str() );
     printf("\niRon will generate a file called \'config.json\' in its current directory. This file\n"\
            "stores your settings. You can edit the file at any time, even while iRon is running,\n"\
            "to customize your overlays and hotkeys.\n\n");
@@ -141,6 +148,7 @@ int main()
     std::vector<Overlay*> overlays;
     overlays.push_back( new OverlayCover() );
     overlays.push_back( new OverlayRelative() );
+    overlays.push_back( new OverlayTrackMap() );
     overlays.push_back( new OverlayInputs() );
     overlays.push_back( new OverlayStandings() );
     overlays.push_back( new OverlayDDU() );
@@ -244,6 +252,9 @@ int main()
                         break;
                     case (int)Hotkey::Cover:
                         g_cfg.setBool( "OverlayCover", "enabled", !g_cfg.getBool("OverlayCover","enabled",true) );
+                        break;
+                    case (int)Hotkey::Map:
+                        g_cfg.setBool( "OverlayTrackMap", "enabled", !g_cfg.getBool("OverlayTrackMap","enabled",true) );
                         break;
                     }
                     


### PR DESCRIPTION
## Summary
- implement `OverlayTrackMap` overlay to draw a basic track map after one lap
- hook new overlay into the app and project files
- document the new overlay and its hotkey

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68688c4a343883318d6e6ba50eda5a6b